### PR TITLE
Simplified fix for positional only overflow

### DIFF
--- a/help.go
+++ b/help.go
@@ -72,7 +72,7 @@ func (p *Parser) getAlignmentInfo() alignmentInfo {
 	var prevcmd *Command
 
 	p.eachActiveGroup(func(c *Command, grp *Group) {
-		if !grp.showInHelp() {
+		if grp.Hidden {
 			return
 		}
 		if c != prevcmd {

--- a/help_test.go
+++ b/help_test.go
@@ -578,3 +578,15 @@ func TestWroteHelp(t *testing.T) {
 		})
 	}
 }
+
+func TestOnlyPositional(t *testing.T) {
+	type options struct {
+		Positional struct {
+			Bar string `description:"bar"`
+		} `positional-args:"yes"`
+	}
+
+	var buf bytes.Buffer
+	NewParser(&options{}, 0).WriteHelp(&buf)
+	// checking for no panic at this point
+}


### PR DESCRIPTION
A Simpler, more performant fix for negative length checking. 

This works because we don't wish to ever skip commands when processing groups, unless it is explicitly hidden. `grp.showInHelp()` will exit early when the group is not hidden, but the group has no options.

This fixes jessevdk#280.